### PR TITLE
Add response format for SwaggerAction

### DIFF
--- a/src/SwaggerAction.php
+++ b/src/SwaggerAction.php
@@ -41,6 +41,8 @@ class SwaggerAction extends Action
     
     public function run()
     {
+        \Yii::$app->response->format = \yii\web\Response::FORMAT_HTML;
+        
         $this->controller->layout = false;
         
         $view = $this->controller->getView();


### PR DESCRIPTION
SwaggerAction 还是需要单独设置下 response format 为 Response::FORMAT_HTML 的。

因为某些实际应用中 response format 可能已经设置在 parent controller 或 config 中，这时候 response format 如果设置为  Response::FORMAT_JSON 或其他格式，文档页是无法成功渲染的。

我用的 yii2-advanced 模板，api 和 frontend、backend 一样都作为独立的 app。它的配置基本都是针对 REST 做的，这时候是需要的。
