### PR TITLE
Add `OPTIONS` and `HEAD` to supported methods

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -33,7 +33,7 @@ SwaggerUIAsset::register($this);
             window.swaggerUi = new SwaggerUi({
                 url: url,
                 dom_id: "swagger-ui-container",
-                supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
+                supportedSubmitMethods: ['options', 'head', 'get', 'post', 'put', 'delete', 'patch'],
                 onComplete: function(swaggerApi, swaggerUi){
                     if(typeof initOAuth == "function") {
                         initOAuth(<?= json_encode($oauthConfig) ?>);


### PR DESCRIPTION
Made `OPTIONS` and `HEAD` methods supported by default since this parameter is not currently configurable and those methods are [available in REST framework](http://www.yiiframework.com/doc-2.0/guide-rest-quick-start.html#trying-it-out) by default.